### PR TITLE
Configure tokenizer padding side

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ from scaling_retriever.modeling.llm_encoder import LlamaBiDense
 
 model = LlamaBiDense.load_from_lora("hzeng/Lion-DS-1B-llama3-marco-mntp") 
 tokenizer = AutoTokenizer.from_pretrained( "hzeng/Lion-DS-1B-llama3-marco-mntp")
+tokenizer.padding_side = "left"
 ```
 
 ### Inference (Toy example)


### PR DESCRIPTION
Set tokenizer padding side to 'left' for LlamaBiDense.
This is essential to recover original performances.